### PR TITLE
Add option to deploy with Oathkeeper

### DIFF
--- a/.oathkeeper/access-rules.yml
+++ b/.oathkeeper/access-rules.yml
@@ -1,0 +1,53 @@
+- id: "ory:kratos:public"
+  upstream:
+    preserve_host: true
+    url: "http://kratos:4433"
+    strip_path: /.ory/kratos/public
+  match:
+    url: "http://127.0.0.1:4455/.ory/kratos/public/<**>"
+    methods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+      - PATCH
+  authenticators:
+    - handler: noop
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: noop
+
+- id: "ory:kratos-ss-ui-react:anonymous"
+  upstream:
+    preserve_host: true
+    url: "http://kratos-ss-ui-react:4435"
+  match:
+    url: "http://127.0.0.1:4455/<{error,recovery,verify,auth/*,**.css,**.js}{/,}>"
+    methods:
+      - GET
+  authenticators:
+    - handler: anonymous
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: noop
+
+- id: "ory:kratos-ss-ui-react:protected"
+  upstream:
+    preserve_host: true
+    url: "http://kratos-ss-ui-react:4435"
+  match:
+    url: "http://127.0.0.1:4455/<{,callback,debug,dashboard,settings}>"
+    methods:
+      - GET
+  authenticators:
+    - handler: cookie_session
+  authorizer:
+    handler: allow
+  mutators:
+    - handler: id_token
+  errors:
+    - handler: redirect
+      config:
+        to: http://127.0.0.1:4455/auth/login

--- a/.oathkeeper/id_token.jwks.json
+++ b/.oathkeeper/id_token.jwks.json
@@ -1,0 +1,18 @@
+{
+  "keys": [
+    {
+      "use": "sig",
+      "kty": "RSA",
+      "kid": "a2aa9739-d753-4a0d-87ee-61f101050277",
+      "alg": "RS256",
+      "n": "zpjSl0ySsdk_YC4ZJYYV-cSznWkzndTo0lyvkYmeBkW60YHuHzXaviHqonY_DjFBdnZC0Vs_QTWmBlZvPzTp4Oni-eOetP-Ce3-B8jkGWpKFOjTLw7uwR3b3jm_mFNiz1dV_utWiweqx62Se0SyYaAXrgStU8-3P2Us7_kz5NnBVL1E7aEP40aB7nytLvPhXau-YhFmUfgykAcov0QrnNY0DH0eTcwL19UysvlKx6Uiu6mnbaFE1qx8X2m2xuLpErfiqj6wLCdCYMWdRTHiVsQMtTzSwuPuXfH7J06GTo3I1cEWN8Mb-RJxlosJA_q7hEd43yYisCO-8szX0lgCasw",
+      "e": "AQAB",
+      "d": "x3dfY_rna1UQTmFToBoMn6Edte47irhkra4VSNPwwaeTTvI-oN2TO51td7vo91_xD1nw-0c5FFGi4V2UfRcudBv9LD1rHt_O8EPUh7QtAUeT3_XXgjx1Xxpqu5goMZpkTyGZ-B6JzOY3L8lvWQ_Qeia1EXpvxC-oTOjJnKZeuwIPlcoNKMRU-mIYOnkRFfnUvrDm7N9UZEp3PfI3vhE9AquP1PEvz5KTUYkubsfmupqqR6FmMUm6ulGT7guhBw9A3vxIYbYGKvXLdBvn68mENrEYxXrwmu6ITMh_y208M5rC-hgEHIAIvMu1aVW6jNgyQTunsGST3UyrSbwjI0K9UQ",
+      "p": "77fDvnfHRFEgyi7mh0c6fAdtMEMJ05W8NwTG_D-cSwfWipfTwJJrroWoRwEgdAg5AWGq-MNUzrubTVXoJdC2T4g1o-VRZkKKYoMvav3CvOIMzCBxBs9I_GAKr5NCSk7maksMqiCTMhmkoZ5RPuMYMY_YzxKNAbjBd9qFLfaVAqs",
+      "q": "3KEmPA2XQkf7dvtpY1Xkp1IfMV_UBdmYk7J6dB5BYqzviQWdEFvWaSATJ_7qV1dw0JDZynOgipp8gvoL-RepfjtArhPz41wB3J2xmBYrBr1sJ-x5eqAvMkQk2bd5KTor44e79TRIkmkFYAIdUQ5JdVXPA13S8WUZfb_bAbwaCBk",
+      "dp": "5uyy32AJkNFKchqeLsE6INMSp0RdSftbtfCfM86fZFQno5lA_qjOnO_avJPkTILDT4ZjqoKYxxJJOEXCffNCPPltGvbE5GrDXsUbP8k2-LgWNeoml7XFjIGEqcCFQoohQ1IK4DTDN6cmRh76C0e_Pbdh15D6TydJEIlsdGuu_kM",
+      "dq": "aegFNYCEojFxeTzX6vIZL2RRSt8oJKK-Be__reu0EUzYMtr5-RdMhev6phFMph54LfXKRc9ZOg9MQ4cJ5klAeDKzKpyzTukkj6U20b2aa8LTvxpZec6YuTVSxxu2Ul71IGRQijTNvVIiXWLGddk409Ub6Q7JqkyQfvdwhpWnnUk",
+      "qi": "P68-EwgcRy9ce_PZ75c909cU7dzCiaGcTX1psJiXmQAFBcG0msWfsyHGbllOZG27pKde78ORGJDYDNk1FqTwsogZyCP87EiBmOoqXWnMvKYfJ1DOx7x42LMAGwMD3bgQj9jgRACxFJG4n3NI6uFlFruyl_CLQzwW_rQFHshLK7Q"
+    }
+  ]
+}

--- a/.oathkeeper/oathkeeper.yml
+++ b/.oathkeeper/oathkeeper.yml
@@ -1,0 +1,88 @@
+log:
+  level: debug
+  format: json
+
+serve:
+  proxy:
+    cors:
+      enabled: true
+      allowed_origins:
+        - "*"
+      allowed_methods:
+        - POST
+        - GET
+        - PUT
+        - PATCH
+        - DELETE
+      allowed_headers:
+        - Authorization
+        - Content-Type
+      exposed_headers:
+        - Content-Type
+      allow_credentials: true
+      debug: true
+
+errors:
+  fallback:
+    - json
+
+  handlers:
+    redirect:
+      enabled: true
+      config:
+        to: http://127.0.0.1:4455/auth/login
+        when:
+          -
+            error:
+              - unauthorized
+              - forbidden
+            request:
+              header:
+                accept:
+                  - text/html
+    json:
+      enabled: true
+      config:
+        verbose: true
+
+access_rules:
+  matching_strategy: glob
+  repositories:
+    - file:///etc/config/oathkeeper/access-rules.yml
+
+authenticators:
+  anonymous:
+    enabled: true
+    config:
+      subject: guest
+
+  cookie_session:
+    enabled: true
+    config:
+      check_session_url: http://kratos:4433/sessions/whoami
+      preserve_path: true
+      extra_from: "@this"
+      subject_from: "identity.id"
+      only:
+        - ory_kratos_session
+
+  noop:
+    enabled: true
+
+authorizers:
+  allow:
+    enabled: true
+
+mutators:
+  noop:
+    enabled: true
+
+  id_token:
+    enabled: true
+    config:
+      issuer_url: http://127.0.0.1:4455/
+      jwks_url: file:///etc/config/oathkeeper/id_token.jwks.json
+      claims: |
+        {
+          "session": {{ .Extra | toJson }}
+        }

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 
 ```
 docker-compose run --rm kratos-ss-ui-react yarn install
-docker-compose up -d
+
+# NGINX proxy
+docker-compose -f docker-compose.yml -f docker-compose-nginx.yml up -d
+# Oathkeeper proxy
+docker-compose -f docker-compose.yml -f docker-compose-oathkeeper.yml up -d
+
 browse 127.0.0.1:4455
 ```
 
 ## Architecture Notes
 
-- For simplicity, NGINX is used instead of Oathkeeper
 - Browser checks for `isAuthenticated` flag in local storage before attempting
   to set authentication session, preventing multiple unnecessary API calls
 - `isAuthenticated` flag is set on the `callback` route, which the user is

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+
+services:
+  nginx:
+    image: "nginx:mainline"
+    depends_on:
+      - kratos
+    ports:
+      - 4455:4455
+      - 4456:4456
+    restart: on-failure
+    networks:
+      - intranet
+    volumes:
+      - ./.nginx/nginx.conf:/etc/nginx/conf.d/default.conf

--- a/docker-compose-oathkeeper.yml
+++ b/docker-compose-oathkeeper.yml
@@ -1,0 +1,22 @@
+version: "3.7"
+
+services:
+  kratos:
+    environment:
+      - SERVE_PUBLIC_BASE_URL=http://127.0.0.1:4455/.ory/kratos/public/
+
+  oathkeeper:
+    image: oryd/oathkeeper:v0.38
+    depends_on:
+      - kratos
+    ports:
+      - 4455:4455
+      - 4456:4456
+    command: serve proxy -c "/etc/config/oathkeeper/oathkeeper.yml"
+    environment:
+      - LOG_LEVEL=debug
+    restart: on-failure
+    networks:
+      - intranet
+    volumes:
+      - ./.oathkeeper:/etc/config/oathkeeper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,19 +62,6 @@ services:
     networks:
       - intranet
 
-  nginx:
-    image: "nginx:mainline"
-    depends_on:
-      - kratos
-    ports:
-      - 4455:4455
-      - 4456:4456
-    restart: on-failure
-    networks:
-      - intranet
-    volumes:
-      - ./.nginx/nginx.conf:/etc/nginx/conf.d/default.conf
-
   mailslurper:
     image: oryd/mailslurper:latest-smtps
     ports:


### PR DESCRIPTION
Move the NGINX proxy config into a separate docker-compose file so that the client can be run behind either NGINX or Oathkeeper.

The config is taken from https://github.com/ory/kratos-selfservice-ui-node, with one modification: add `/callback` to the "protected" URL matcher.